### PR TITLE
Ensure logo files are not empty, Keep logos inside displays

### DIFF
--- a/arch-xdm/Xsetup
+++ b/arch-xdm/Xsetup
@@ -18,7 +18,7 @@ if [[ ! -d ${CACHE_DIR} ]]; then
 fi
 
 # check whether image file already exists
-if [[ ! -f ${IMAGEFILE} ]]; then
+if [[ ! -f ${IMAGEFILE} ]] || [[ ! -s ${IMAGEFILE} ]]; then
   rsvg-convert -a --background-color="#000000" -f png -w $((${RESOLUTION[0]}/3*2)) -o ${IMAGEFILE} ${SVG_FILE}
 fi
 

--- a/arch-xdm/Xsetup
+++ b/arch-xdm/Xsetup
@@ -19,7 +19,11 @@ fi
 
 # check whether image file already exists
 if [[ ! -f ${IMAGEFILE} ]] || [[ ! -s ${IMAGEFILE} ]]; then
-  rsvg-convert -a --background-color="#000000" -f png -w $((${RESOLUTION[0]}/3*2)) -o ${IMAGEFILE} ${SVG_FILE}
+  if [[ ${RESOLUTION[0]}/${RESOLUTION[1]} -le 3 ]]; then
+    rsvg-convert -a --background-color="#000000" -f png -w $((${RESOLUTION[0]}/3*2)) -o ${IMAGEFILE} ${SVG_FILE}
+  else
+    rsvg-convert -a --background-color="#000000" -f png -h $((${RESOLUTION[1]}/5*2)) -o ${IMAGEFILE} ${SVG_FILE}
+  fi
 fi
 
 # try different methods to set the background


### PR DESCRIPTION
This just fixes a couple simple things:

- For some reason I ended up with an empty logo file. Since the file existed, it wasn't rebuilt.
- The logo ends up being too large on extra wide displays.